### PR TITLE
Add 'reports' module and Kover plugin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,3 +37,11 @@ jobs:
         with:
           report_paths: '**/*-reports/TEST-*.xml'
           annotate_only: true
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: "reports/target/site/kover/report.xml"
+          # or a comma-separated list for multiple reports
+          # coverage-reports: <PATH_TO_REPORT>, <PATH_TO_REPORT>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: Kotlin CI with Maven
 
 on:
   push:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Dkotlin.compiler.incremental=true
+-T12C

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # langchain4j-kotlin
-[![Java CI with Maven](https://github.com/kpavlov/langchain4j-kotlin/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/kpavlov/langchain4j-kotlin/actions/workflows/maven.yml)
+[![Kotlin CI with Maven](https://github.com/kpavlov/langchain4j-kotlin/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/kpavlov/langchain4j-kotlin/actions/workflows/maven.yml)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/644f664ad05a4a009b299bc24c8be4b8)](https://app.codacy.com/gh/kpavlov/langchain4j-kotlin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Coverage](https://app.codacy.com/project/badge/Coverage/644f664ad05a4a009b299bc24c8be4b8)](https://app.codacy.com/gh/kpavlov/langchain4j-kotlin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 Kotlin enhancements for [LangChain4j](https://github.com/langchain4j/langchain4j).
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>langchain4j-core-kotlin</module>
+        <module>reports</module>
     </modules>
 
     <properties>
@@ -150,6 +151,11 @@
                     <artifactId>detekt-maven-plugin</artifactId>
                     <version>1.23.7</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kover-maven-plugin</artifactId>
+                    <version>0.9.0-RC</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -186,6 +192,25 @@
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- https://kotlin.github.io/kotlinx-kover/maven-plugin/#goals -->
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kover-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>instr</id>
+                        <goals>
+                            <goal>instrumentation</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>kover-log</id>
+                        <goals>
+                            <goal>log</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>me.kpavlov.langchain4j.kotlin</groupId>
+        <artifactId>langchain4j-kotlin-aggregator</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>reports</artifactId>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>me.kpavlov.langchain4j.kotlin</groupId>
+            <artifactId>langchain4j-core-kotlin</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kover-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>kover-xml</id>
+                        <goals>
+                            <goal>report-xml</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>kover-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <aggregate>true</aggregate>
+                    <logGroupBy>CLASS</logGroupBy>
+                    <warningInsteadOfFailure>true</warningInsteadOfFailure>
+                    <rules>
+                        <rule>
+                            <groupBy>CLASS</groupBy>
+                            <bounds>
+                                <bound>
+                                    <aggregationForGroup>COVERED_COUNT</aggregationForGroup>
+                                    <minValue>100</minValue>
+                                </bound>
+                            </bounds>
+                        </rule>
+                    </rules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
This pull request includes several changes to integrate Kotlin enhancements, add coverage reporting, and update the build configuration for the project. The most important changes are listed below:

### Build and CI Configuration:

* Updated the CI workflow name from "Java CI with Maven" to "Kotlin CI with Maven" in `.github/workflows/maven.yml`.
* Added a step to run `codacy-coverage-reporter` in the CI workflow.
* Enabled parallel build with 12 threads in `.mvn/maven.config`.

### Maven and Reporting:

* Added the `reports` module to the `pom.xml` file to include coverage reporting.
* Integrated the `kover-maven-plugin` for Kotlin code coverage reporting in `pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R154-R158) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R199-R217)

### Documentation:

* Updated the badge in `README.md` to reflect the new CI workflow name and added a badge for Codacy coverage.

### New Files:

* Added `reports/pom.xml` to configure the `kover-maven-plugin` for generating and verifying coverage reports.