### PR TITLE
External templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,4 @@ ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
 # noinspection EditorConfigKeyCorrectness
 ktlint_function_naming_ignore_when_annotated_with = "Test"
+ij_kotlin_packages_to_use_import_on_demand = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -30,3 +30,6 @@ ij_kotlin_name_count_to_use_star_import_for_members = 999
 # noinspection EditorConfigKeyCorrectness
 ktlint_function_naming_ignore_when_annotated_with = "Test"
 ij_kotlin_packages_to_use_import_on_demand = unset
+
+[*.mustache]
+insert_final_newline = false

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/Configuration.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/Configuration.kt
@@ -1,9 +1,18 @@
 package me.kpavlov.langchain4j.kotlin
 
+import me.kpavlov.langchain4j.kotlin.prompt.PromptTemplateSource
+import me.kpavlov.langchain4j.kotlin.prompt.TemplateRenderer
 import java.util.Properties
 
 object Configuration {
     val properties: Properties = loadProperties()
+
+    operator fun get(key: String): String = properties.getProperty(key)
+
+    val promptTemplateSource: PromptTemplateSource =
+        createInstanceByName(this["prompt.template.source"])
+    val promptTemplateRenderer: TemplateRenderer =
+        createInstanceByName(this["prompt.template.renderer"])
 }
 
 private fun loadProperties(fileName: String = "langchain4j-kotlin.properties"): Properties {
@@ -17,3 +26,14 @@ private fun loadProperties(fileName: String = "langchain4j-kotlin.properties"): 
     }
     return properties
 }
+
+@Suppress("UNCHECKED_CAST", "TooGenericExceptionCaught")
+private fun <T> createInstanceByName(className: String): T =
+    try {
+        // Get the class object by name
+        val clazz = Class.forName(className)
+        // Create an instance of the class
+        clazz.getDeclaredConstructor().newInstance() as T
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Can't create $className", e)
+    }

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/Configuration.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/Configuration.kt
@@ -1,0 +1,19 @@
+package me.kpavlov.langchain4j.kotlin
+
+import java.util.Properties
+
+object Configuration {
+    val properties: Properties = loadProperties()
+}
+
+private fun loadProperties(fileName: String = "langchain4j-kotlin.properties"): Properties {
+    val properties = Properties()
+    val classLoader = Thread.currentThread().contextClassLoader
+    classLoader.getResourceAsStream(fileName).use { inputStream ->
+        require(inputStream != null) {
+            "Property file '$fileName' not found in the classpath"
+        }
+        properties.load(inputStream)
+    }
+    return properties
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ClasspathPromptTemplateSource.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ClasspathPromptTemplateSource.kt
@@ -1,0 +1,11 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+class ClasspathPromptTemplateSource : PromptTemplateSource {
+    override fun getTemplate(name: String): PromptTemplate? {
+        val resourceStream = this::class.java.classLoader.getResourceAsStream(name)
+        return resourceStream?.bufferedReader()?.use { reader ->
+            val content = reader.readText()
+            return SimplePromptTemplate(content)
+        }
+    }
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ExtendedPromptTemplate.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ExtendedPromptTemplate.kt
@@ -6,9 +6,11 @@ private val logger = LoggerFactory.getLogger(ExtendedPromptTemplate::class.java)
 
 class ExtendedPromptTemplate(
     val name: String,
-    val content: String,
+    private val content: String,
     private val templateRenderer: TemplateRenderer = SimpleTemplateRenderer,
-) : dev.langchain4j.spi.prompt.PromptTemplateFactory.Template {
+) : PromptTemplate {
+    override fun content(): String = content
+
     override fun render(variables: Map<String, Any>): String {
         logger.info("Rendering template: {}", name)
         return templateRenderer.render(template = content, variables = variables)

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ExtendedPromptTemplate.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ExtendedPromptTemplate.kt
@@ -1,0 +1,16 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(ExtendedPromptTemplate::class.java)
+
+class ExtendedPromptTemplate(
+    val name: String,
+    val content: String,
+    private val templateRenderer: TemplateRenderer = SimpleTemplateRenderer,
+) : dev.langchain4j.spi.prompt.PromptTemplateFactory.Template {
+    override fun render(variables: Map<String, Any>): String {
+        logger.info("Rendering template: {}", name)
+        return templateRenderer.render(template = content, variables = variables)
+    }
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplate.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplate.kt
@@ -1,0 +1,5 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+interface PromptTemplate : dev.langchain4j.spi.prompt.PromptTemplateFactory.Template {
+    fun content(): String
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplate.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplate.kt
@@ -1,5 +1,11 @@
 package me.kpavlov.langchain4j.kotlin.prompt
 
-interface PromptTemplate : dev.langchain4j.spi.prompt.PromptTemplateFactory.Template {
+public interface PromptTemplate {
     fun content(): String
+}
+
+public data class SimplePromptTemplate(
+    private val content: String,
+) : PromptTemplate {
+    override fun content(): String = content
 }

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateFactory.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateFactory.kt
@@ -1,0 +1,39 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+import dev.langchain4j.spi.prompt.PromptTemplateFactory
+import me.kpavlov.langchain4j.kotlin.Configuration
+
+class PromptTemplateFactory : PromptTemplateFactory {
+    private val source: PromptTemplateSource = Configuration.promptTemplateSource
+    private val renderer: TemplateRenderer = Configuration.promptTemplateRenderer
+
+    init {
+        Configuration.properties.getProperty("prompt.template.source")?.let {
+            println("Found prompt template source: $it")
+        }
+        Configuration.properties.getProperty("prompt.template.renderer")?.let {
+            println("Found prompt template source: $it")
+        }
+        println("PromptTemplateFactory initialized.")
+    }
+
+    override fun create(input: PromptTemplateFactory.Input): PromptTemplateFactory.Template {
+        println(
+            "Create PromptTemplate input.template = ${input.template}, input.name = ${input.name}",
+        )
+        val template = source.getTemplate(input.template)
+        return if (template == null) {
+            RenderablePromptTemplate(
+                name = input.name,
+                content = input.template,
+                templateRenderer = renderer,
+            )
+        } else {
+            RenderablePromptTemplate(
+                name = input.template,
+                content = template.content(),
+                templateRenderer = renderer,
+            )
+        }
+    }
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateSource.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateSource.kt
@@ -1,0 +1,5 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+interface PromptTemplateSource {
+    fun getTemplate(name: String): PromptTemplate?
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/RenderablePromptTemplate.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/RenderablePromptTemplate.kt
@@ -2,13 +2,14 @@ package me.kpavlov.langchain4j.kotlin.prompt
 
 import org.slf4j.LoggerFactory
 
-private val logger = LoggerFactory.getLogger(ExtendedPromptTemplate::class.java)
+private val logger = LoggerFactory.getLogger(RenderablePromptTemplate::class.java)
 
-class ExtendedPromptTemplate(
+class RenderablePromptTemplate(
     val name: String,
     private val content: String,
-    private val templateRenderer: TemplateRenderer = SimpleTemplateRenderer,
-) : PromptTemplate {
+    private val templateRenderer: TemplateRenderer,
+) : PromptTemplate,
+    dev.langchain4j.spi.prompt.PromptTemplateFactory.Template {
     override fun content(): String = content
 
     override fun render(variables: Map<String, Any>): String {

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRenderer.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRenderer.kt
@@ -1,7 +1,7 @@
 package me.kpavlov.langchain4j.kotlin.prompt
 
-public object SimpleTemplateRenderer : TemplateRenderer {
-    override fun render(
+public class SimpleTemplateRenderer : TemplateRenderer {
+    public override fun render(
         template: String,
         variables: Map<String, Any?>,
     ): String {

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRenderer.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRenderer.kt
@@ -1,0 +1,28 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+public object SimpleTemplateRenderer : TemplateRenderer {
+    override fun render(
+        template: String,
+        variables: Map<String, Any?>,
+    ): String {
+        val undefinedKeys =
+            "\\{\\{(\\w+)\\}\\}"
+                .toRegex()
+                .findAll(template)
+                .map { it.groupValues[1] }
+                .filterNot { variables.containsKey(it) }
+                .toList()
+
+        require(undefinedKeys.isEmpty()) {
+            "Undefined keys in template: ${
+                undefinedKeys.joinToString(
+                    ", ",
+                )
+            }"
+        }
+
+        return variables.entries.fold(template) { acc, entry ->
+            acc.replace("{{${entry.key}}}", entry.value?.toString() ?: "")
+        }
+    }
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/TemplateRenderer.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/TemplateRenderer.kt
@@ -1,0 +1,8 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+public interface TemplateRenderer {
+    public fun render(
+        template: String,
+        variables: Map<String, Any?>,
+    ): String
+}

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProvider.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProvider.kt
@@ -1,0 +1,23 @@
+package me.kpavlov.langchain4j.kotlin.service
+
+import me.kpavlov.langchain4j.kotlin.ChatMemoryId
+import me.kpavlov.langchain4j.kotlin.Configuration
+import me.kpavlov.langchain4j.kotlin.prompt.PromptTemplateSource
+import me.kpavlov.langchain4j.kotlin.prompt.TemplateRenderer
+
+public open class TemplateSystemMessageProvider(
+    private val templateName: String,
+    private val promptTemplateSource: PromptTemplateSource = Configuration.promptTemplateSource,
+    private val promptTemplateRenderer: TemplateRenderer = Configuration.promptTemplateRenderer,
+) : SystemMessageProvider {
+    public open fun templateName(): String = templateName
+
+    override fun getSystemMessage(chatMemoryID: ChatMemoryId): String? {
+        val promptTemplate = promptTemplateSource.getTemplate(templateName())
+        require(promptTemplate != null) {
+            "Can't find SystemPrompt template with name=\"$templateName()\""
+        }
+        val content = promptTemplate.content()
+        return promptTemplateRenderer.render(content, mapOf("chatMemoryID" to chatMemoryID))
+    }
+}

--- a/langchain4j-kotlin/src/main/resources/META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory
+++ b/langchain4j-kotlin/src/main/resources/META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory
@@ -1,0 +1,1 @@
+me.kpavlov.langchain4j.kotlin.prompt.PromptTemplateFactory

--- a/langchain4j-kotlin/src/main/resources/langchain4j-kotlin.properties
+++ b/langchain4j-kotlin/src/main/resources/langchain4j-kotlin.properties
@@ -1,0 +1,2 @@
+prompt.template.source=me.kpavlov.langchain4j.kotlin.prompt.ClasspathPromptTemplateSource
+prompt.template.renderer=me.kpavlov.langchain4j.kotlin.prompt.SimpleTemplateRenderer

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRendererTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRendererTest.kt
@@ -1,0 +1,52 @@
+package me.kpavlov.langchain4j.kotlin.prompt
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SimpleTemplateRendererTest {
+    @Test
+    fun `render returns original string when no placeholders are present`() {
+        val template = "No placeholders here"
+        val variables: Map<String, Any?> = mapOf("key" to "value")
+
+        val result = SimpleTemplateRenderer.render(template, variables)
+
+        assertEquals(template, result)
+    }
+
+    @Test
+    fun `render replaces placeholders with variable values`() {
+        val template = "Hello, {{name}}"
+        val variables: Map<String, Any?> = mapOf("name" to "John")
+
+        val result = SimpleTemplateRenderer.render(template, variables)
+
+        assertEquals("Hello, John", result)
+    }
+
+    @Test
+    fun `render replaces multiple placeholders with variable values`() {
+        val template = "Hello, {{name}}, you are {{age}} years old."
+        val variables: Map<String, Any?> = mapOf("name" to "John", "age" to 47)
+
+        val result = SimpleTemplateRenderer.render(template, variables)
+
+        assertEquals("Hello, John, you are 47 years old.", result)
+    }
+
+    @Test
+    fun `render replaces undefined placeholders with an empty string`() {
+        val template = "Hello, {{customer}}! My name is {{agent}}."
+        val variables: Map<String, Any?> = mapOf()
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                SimpleTemplateRenderer.render(
+                    template,
+                    variables,
+                )
+            }
+        assertEquals("Undefined keys in template: customer, agent", exception.message)
+    }
+}

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRendererTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRendererTest.kt
@@ -5,12 +5,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class SimpleTemplateRendererTest {
+    private val subject = SimpleTemplateRenderer()
+
     @Test
     fun `render returns original string when no placeholders are present`() {
         val template = "No placeholders here"
         val variables: Map<String, Any?> = mapOf("key" to "value")
 
-        val result = SimpleTemplateRenderer.render(template, variables)
+        val result = subject.render(template, variables)
 
         assertEquals(template, result)
     }
@@ -20,7 +22,7 @@ class SimpleTemplateRendererTest {
         val template = "Hello, {{name}}"
         val variables: Map<String, Any?> = mapOf("name" to "John")
 
-        val result = SimpleTemplateRenderer.render(template, variables)
+        val result = subject.render(template, variables)
 
         assertEquals("Hello, John", result)
     }
@@ -30,7 +32,7 @@ class SimpleTemplateRendererTest {
         val template = "Hello, {{name}}, you are {{age}} years old."
         val variables: Map<String, Any?> = mapOf("name" to "John", "age" to 47)
 
-        val result = SimpleTemplateRenderer.render(template, variables)
+        val result = subject.render(template, variables)
 
         assertEquals("Hello, John, you are 47 years old.", result)
     }
@@ -42,7 +44,7 @@ class SimpleTemplateRendererTest {
 
         val exception =
             assertThrows<IllegalArgumentException> {
-                SimpleTemplateRenderer.render(
+                subject.render(
                     template,
                     variables,
                 )

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt
@@ -1,0 +1,65 @@
+package me.kpavlov.langchain4j.kotlin.service
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.model.chat.ChatLanguageModel
+import dev.langchain4j.model.output.Response
+import dev.langchain4j.service.AiServices
+import dev.langchain4j.service.UserName
+import dev.langchain4j.service.V
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class ServiceWithPromptTemplatesTest {
+    private lateinit var model: ChatLanguageModel
+
+    @Test
+    fun `Should use System and User Prompt Templates`() {
+        model =
+            ChatLanguageModel {
+                assertThat(
+                    it[0],
+                ).isEqualTo(
+                    SystemMessage.from("You are helpful assistant using chatMemoryID=default"),
+                )
+                assertThat(it[1])
+                    .isInstanceOf(UserMessage::class.java)
+                    .given { userPrompt ->
+                        assertThat(
+                            userPrompt.singleText(),
+                        ).isEqualTo("Hello, My friend! How are you?")
+                    }
+                Response.from(AiMessage.from("I'm fine, thanks"))
+            }
+
+        val assistant =
+            AiServices
+                .builder(Assistant::class.java)
+                .systemMessageProvider(
+                    TemplateSystemMessageProvider(
+                        "prompts/ServiceWithTemplatesTest/default-system-prompt.mustache",
+                    ),
+                ).chatLanguageModel(model)
+                .build()
+
+        val response = assistant.askQuestion(userName = "My friend", question = "How are you?")
+        assertThat(response).isEqualTo("I'm fine, thanks")
+    }
+
+    @Suppress("unused")
+    private interface Assistant {
+        @dev.langchain4j.service.UserMessage(
+            "prompts/ServiceWithTemplatesTest/default-user-prompt.mustache",
+        )
+        fun askQuestion(
+            @UserName userName: String,
+            @V("message") question: String,
+        ): String
+    }
+}

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProviderTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProviderTest.kt
@@ -1,0 +1,64 @@
+package me.kpavlov.langchain4j.kotlin.service
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import me.kpavlov.langchain4j.kotlin.ChatMemoryId
+import me.kpavlov.langchain4j.kotlin.prompt.PromptTemplate
+import me.kpavlov.langchain4j.kotlin.prompt.PromptTemplateSource
+import me.kpavlov.langchain4j.kotlin.prompt.TemplateRenderer
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class TemplateSystemMessageProviderTest {
+    @Mock
+    lateinit var templateSourceMock: PromptTemplateSource
+
+    @Mock
+    lateinit var templateRenderer: TemplateRenderer
+
+    @Mock
+    lateinit var promptTemplate: PromptTemplate
+
+    @Mock
+    lateinit var chatMemoryId: ChatMemoryId
+
+    lateinit var templateName: String
+
+    lateinit var subject: TemplateSystemMessageProvider
+
+    @BeforeEach
+    fun beforeEach() {
+        templateName = "templateName-${System.currentTimeMillis()}"
+        subject = TemplateSystemMessageProvider(templateName, templateSourceMock, templateRenderer)
+    }
+
+    @Test
+    fun `getSystemMessage returns expected message when template exists`() {
+        whenever(templateSourceMock.getTemplate(templateName)).thenReturn(promptTemplate)
+        whenever(promptTemplate.content()).thenReturn("content")
+        whenever(templateRenderer.render(eq("content"), any())).thenReturn("result")
+
+        val result = subject.getSystemMessage(chatMemoryId)
+
+        assertThat(result).isEqualTo("result")
+    }
+
+    @Test
+    fun `getSystemMessage throws IllegalArgumentException when template is not found`() {
+        whenever(templateSourceMock.getTemplate(templateName)).thenReturn(null)
+
+        assertThrows<IllegalArgumentException> {
+            subject.getSystemMessage(
+                ChatMemoryId(),
+            )
+        }
+    }
+}

--- a/langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-system-prompt.mustache
+++ b/langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-system-prompt.mustache
@@ -1,0 +1,1 @@
+You are helpful assistant using chatMemoryID={{chatMemoryID}}

--- a/langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-user-prompt.mustache
+++ b/langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-user-prompt.mustache
@@ -1,0 +1,1 @@
+Hello, {{userName}}! {{message}}


### PR DESCRIPTION
This pull request introduces a new configuration and template system for the `langchain4j-kotlin` project. The changes include the addition of a configuration object, several template-related classes, and corresponding tests. Below are the most important changes:

### Configuration and Template System:

* **Configuration Object:**
  - Added `Configuration` object to manage properties and provide instances of `PromptTemplateSource` and `TemplateRenderer`. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/Configuration.kt`)

* **Template Source and Renderer:**
  - Introduced `PromptTemplateSource` interface and its implementation `ClasspathPromptTemplateSource` to load templates from the classpath. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateSource.kt`, `langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/ClasspathPromptTemplateSource.kt`) [[1]](diffhunk://#diff-da93547f2bcc3ec0e43964584c89962e271880a97e71dd696ab97357c6feaf8fR1-R5) [[2]](diffhunk://#diff-ea20e31ff25290ca243e2a77a962dabcb27c577a4bde31a00d850325ced0beb1R1-R11)
  - Added `TemplateRenderer` interface and its implementation `SimpleTemplateRenderer` for rendering templates with variables. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/TemplateRenderer.kt`, `langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRenderer.kt`) [[1]](diffhunk://#diff-ba2e4ac01a6ee49c9cd430ef0484e79b9053f75baa18088431faf95d08ca304cR1-R8) [[2]](diffhunk://#diff-cef22be46f6917ba27017c3c8d4dc07ceb8a48c7ccb22ba3627a52629bb111f5R1-R28)

* **Prompt Templates:**
  - Created `PromptTemplate` interface and `SimplePromptTemplate` data class to represent template content. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplate.kt`)
  - Added `RenderablePromptTemplate` class to support rendering templates with variables. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/RenderablePromptTemplate.kt`)

* **Factory and Service:**
  - Implemented `PromptTemplateFactory` to create prompt templates using the configuration. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/prompt/PromptTemplateFactory.kt`)
  - Added `TemplateSystemMessageProvider` to provide system messages using templates. (`langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProvider.kt`)

### Tests:

* **Unit Tests:**
  - Added unit tests for `SimpleTemplateRenderer` to verify template rendering functionality. (`langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/prompt/SimpleTemplateRendererTest.kt`)
  - Added unit tests for `TemplateSystemMessageProvider` to ensure correct system message generation. (`langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProviderTest.kt`)

* **Integration Tests:**
  - Added integration test for a service using prompt templates to verify end-to-end functionality. (`langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt`)

### Configuration Files:

* **Properties and Service Configuration:**
  - Added properties file to specify the template source and renderer implementations. (`langchain4j-kotlin/src/main/resources/langchain4j-kotlin.properties`)
  - Registered `PromptTemplateFactory` in the service configuration. (`langchain4j-kotlin/src/main/resources/META-INF/services/dev.langchain4j.spi.prompt.PromptTemplateFactory`)

* **Template Files:**
  - Added default system and user prompt templates for testing. (`langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-system-prompt.mustache`, `langchain4j-kotlin/src/test/resources/prompts/ServiceWithTemplatesTest/default-user-prompt.mustache`) [[1]](diffhunk://#diff-12f461cd365d8aa788e1f89478da9b3944c30b1193b52725fbfeff803bf441a2R1) [[2]](diffhunk://#diff-2e4812975ee3c648b19015f65c7c37516e4f22853d0060be42691a23ec1d32feR1)