### PR TITLE
Update langchain4j version to 0.36.2

### DIFF
--- a/langchain4j-kotlin/notebooks/lc4kNotebook.ipynb
+++ b/langchain4j-kotlin/notebooks/lc4kNotebook.ipynb
@@ -8,8 +8,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-13T22:06:53.575508Z",
-     "start_time": "2024-11-13T22:06:53.416656Z"
+     "end_time": "2024-11-22T05:39:35.370383Z",
+     "start_time": "2024-11-22T05:39:35.118075Z"
     }
    },
    "cell_type": "code",
@@ -17,8 +17,8 @@
     "%useLatestDescriptors\n",
     "%use coroutines\n",
     "\n",
-    "@file:DependsOn(\"dev.langchain4j:langchain4j:0.36.0\")\n",
-    "@file:DependsOn(\"dev.langchain4j:langchain4j-open-ai:0.36.0\")\n",
+    "@file:DependsOn(\"dev.langchain4j:langchain4j:0.36.2\")\n",
+    "@file:DependsOn(\"dev.langchain4j:langchain4j-open-ai:0.36.2\")\n",
     "\n",
     "// add maven dependency\n",
     "@file:DependsOn(\"me.kpavlov.langchain4j.kotlin:langchain4j-kotlin:0.1.1\")\n",
@@ -26,13 +26,13 @@
     "//@file:DependsOn(\"../target/classes\")"
    ],
    "outputs": [],
-   "execution_count": 13
+   "execution_count": 5
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-13T22:06:54.840954Z",
-     "start_time": "2024-11-13T22:06:53.578200Z"
+     "end_time": "2024-11-22T05:39:31.262632Z",
+     "start_time": "2024-11-22T05:39:29.397246Z"
     }
    },
    "cell_type": "code",
@@ -72,7 +72,19 @@
      ]
     }
    ],
-   "execution_count": 14
+   "execution_count": 3
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-22T05:39:31.268817Z",
+     "start_time": "2024-11-22T05:39:31.267196Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "",
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <finchly.version>0.1.1</finchly.version>
         <junit.version>5.11.3</junit.version>
         <kotlinx.version>1.9.0</kotlinx.version>
-        <langchain4j.version>0.36.1</langchain4j.version>
+        <langchain4j.version>0.36.2</langchain4j.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <mockito.version>5.14.2</mockito.version>
         <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
Updates to the dependencies and execution metadata in the `lc4kNotebook.ipynb` file, as well as a version bump for the `langchain4j` dependency in the `pom.xml` file. Below are the most important changes:

Dependency updates:

* [`langchain4j-kotlin/notebooks/lc4kNotebook.ipynb`](diffhunk://#diff-5845ad308fb2b8e1a81d68b05ef2d14ebf7f079c689fd8a3aef833bd8b928bd4L11-R35): Updated `langchain4j` and `langchain4j-open-ai` dependencies from version `0.36.0` to `0.36.2`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L57-R57): Updated `langchain4j` dependency version from `0.36.1` to `0.36.2`.

Execution metadata changes:

* [`langchain4j-kotlin/notebooks/lc4kNotebook.ipynb`](diffhunk://#diff-5845ad308fb2b8e1a81d68b05ef2d14ebf7f079c689fd8a3aef833bd8b928bd4L11-R35): Updated the execution start and end times for code cells. [[1]](diffhunk://#diff-5845ad308fb2b8e1a81d68b05ef2d14ebf7f079c689fd8a3aef833bd8b928bd4L11-R35) [[2]](diffhunk://#diff-5845ad308fb2b8e1a81d68b05ef2d14ebf7f079c689fd8a3aef833bd8b928bd4L75-R87)
* [`langchain4j-kotlin/notebooks/lc4kNotebook.ipynb`](diffhunk://#diff-5845ad308fb2b8e1a81d68b05ef2d14ebf7f079c689fd8a3aef833bd8b928bd4L75-R87): Added a new empty code cell with execution metadata.