### PR TITLE
Add automated API docs generation and deployment workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,43 @@
+name: Build and Publish Docs to GitHub Pages
+
+on:
+  release:
+    types:
+      - created
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  deploy:
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Generate Dokka Site
+        run: |-
+          mvn dokka:dokka -pl !reports && \
+          cp -R langchain4j-kotlin/target/dokka target/docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/docs/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 build:
 	  mvn clean verify site
 
+apidocs:
+	  mvn clean dokka:dokka -pl !reports && \
+    mkdir -p target/docs && \
+		cp -R langchain4j-kotlin/target/dokka target/docs/api
+
 lint:prepare
 	  ktlint && \
     mvn spotless:check
@@ -17,3 +22,4 @@ prepare:
 	  brew install ktlint --quiet
 
 all: format lint build
+


### PR DESCRIPTION
This commit introduces a new Makefile target, `apidocs`, which organizes the generation of API documentation using Dokka. Additionally, a GitHub Actions workflow is added to automatically build and publish the documentation to GitHub Pages upon a release or manual trigger. These changes streamline the documentation process, ensuring up-to-date docs are easily accessible.