### PR TITLE
Kotlin 1.9 compatibility, langchain4j 1.0.0-alpha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Kotlin enhancements for [LangChain4j](https://github.com/langchain4j/langchain4j
 
 See the [discussion](https://github.com/langchain4j/langchain4j/discussions/1897) on LangChain4j project.
 
-> ℹ️ I am verifying my ideas for improving LangChain4j here. If an idea is accepted, the code might be adopted into the original [LangChain4j](https://github.com/langchain4j) project. If not - you may enjoy it here.
+> ℹ️ This project is a playground for [LangChain4j's Kotlin API](https://docs.langchain4j.dev/tutorials/kotlin). If
+> accepted, some code might be adopted into the original [LangChain4j](https://github.com/langchain4j) project and removed
+> from here. Mean while, enjoy it here.
 
 ## Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <kotlin.code.style>official</kotlin.code.style>
         <java.version>17</java.version>
         <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.api.version>1.9</kotlin.api.version>
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -54,7 +55,7 @@
         <finchly.version>0.1.1</finchly.version>
         <junit.version>5.11.4</junit.version>
         <kotlinx.version>1.10.1</kotlinx.version>
-        <langchain4j.version>0.36.2</langchain4j.version>
+        <langchain4j.version>1.0.0-alpha1</langchain4j.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <mockito.version>5.15.2</mockito.version>
         <slf4j.version>2.0.16</slf4j.version>
@@ -276,6 +277,9 @@
                         <!--<arg>-Werror</arg>-->
                     </args>
                     <javaParameters>true</javaParameters>
+                    <multiPlatform>true</multiPlatform>
+                    <languageVersion>${kotlin.api.version}</languageVersion>
+                    <apiVersion>${kotlin.api.version}</apiVersion>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Added Kotlin API version 1.9 and updated langchain4j to 1.0.0-alpha1 in `pom.xml` for compatibility and new features. Configured Kotlin compiler with multi-platform support and aligned language and API versions for consistency.