### PR TITLE
Refactor and enhance template system handling

### DIFF
--- a/docs/PromptTemplates.md
+++ b/docs/PromptTemplates.md
@@ -1,105 +1,80 @@
-# Customizing Prompt Templates
+# Prompt Templates Guide
 
-This guide demonstrates how to configure and use prompt templates with
-the [LangChain4J's AiServices](https://docs.langchain4j.dev/tutorials/ai-services). This setup involves configuring
-prompt templates, defining and extending prompt template sources and template rendering.
+Learn how to use prompt templates with LangChain4J's AiServices. This guide covers setup, configuration, and
+customization.
 
-## Creating and Using Prompt Template
+## Create Your First Template
 
-Let's start with built-in mechanism of loading prompt template from classpath. Your prompt templates should be located
-in the classpath, e.g.
+Place your prompt templates in the classpath:
 
-File: `prompts/default-system-prompt.mustache`
-
+System prompt template:
 ```mustache
+prompts/default-system-prompt.mustache:
 You are helpful assistant using chatMemoryID={{chatMemoryID}}
 ```
 
-File: `prompts/default-user-prompt.mustache`
-
+User prompt template:
 ```mustache
+prompts/default-user-prompt.mustache:
 Hello, {{userName}}! {{message}}
 ```
 
-## Example with AiServices
+## Quick Start
 
-Define an interface that uses these templates and configure the AiServices builder:
+Here's how to use templates in your code:
 
 ```kotlin
-// Define assistant interface
+// Define your assistant
 interface Assistant {
-  @UserMessage(
-    // "Hello, {{userName}}! {{message}}"
-    "prompts/default-user-prompt.mustache", //template name/resource
-  )
+  @UserMessage("prompts/default-user-prompt.mustache")
   fun askQuestion(
-    @UserName userName: String,
+    @UserName userName: String, // Compile with javac `parameters=true` 
     @V("message") question: String,
   ): String
 }
 
-// Define Chain of Thoughts
+// Set up the assistant
 val assistant: Assistant =
   AiServices
     .builder(Assistant::class.java)
     .systemMessageProvider(
-      TemplateSystemMessageProvider(
-        // "You are helpful assistant using chatMemoryID={{chatMemoryID}}"
-        "prompts/default-system-prompt.mustache", // template name/recource
-      ),
+      TemplateSystemMessageProvider("prompts/default-system-prompt.mustache")
     ).chatLanguageModel(model)
     .build()
 
-// Run it!
-val response =
-  assistant.askQuestion(
-    userName = "My friend",
-    question = "How are you?",
-  )
+// Use it
+val response = assistant.askQuestion(
+  userName = "My friend",
+  question = "How are you?"
+)
 ```
 
-System and user prompts will be:
+This creates:
 
-- **System prompt:** "You are helpful assistant using chatMemoryID=default"
-- **User Prompt:** "Hello, My friend! How are you?"
+- System prompt: "You are helpful assistant using chatMemoryID=default"
+- User prompt: "Hello, My friend! How are you?"
 
-## How does it work
+## Under the Hood
 
-In the default implementation, `TemplateSystemMessageProvider` handles the system prompt template and `AiServices` uses
-the templates to generate prompts.
+Key components:
 
-`PromptTemplateFactory` provides `PromptTemplateFactory.Template` for `AiServices`. It is registered automatically via
-Java ServiceLoaders mechanism. This class is responsible for obtaining prompt templates from a `PromptTemplateSource`.
-If the specified template cannot be found, it will fallback to using default LC4J's the input template content.
+- `PromptTemplateFactory`: Gets templates and handles defaults
+- `ClasspathPromptTemplateSource`: Loads templates from your classpath
+- `SimpleTemplateRenderer`: Replaces `{{key}}` placeholders with values
+- `RenderablePromptTemplate`: Connects everything together
 
-`ClasspathPromptTemplateSource` is implementing `PromptTemplateSource` interface and provides a mechanism to load prompt
-templates from the classpath using the template name as the resource identifier. It attempts to locate the template file
-in the classpath and reads its contents as the template data. It is registered via property file and might be
-overridden.
+## Customize Your Setup
 
-Implementers of the `TemplateRenderer` interface will typically replace placeholders in the template with corresponding
-values from the variables map.
+Configure templates in `langchain4j-kotlin.properties`:
 
-`SimpleTemplateRenderer` finds and replaces placeholders in the template in the Mustache-like format `{{key}}`, where
-`key`
-corresponds to an entry in the variables map. If any placeholders in the template are not defined in the variables map,
-an `IllegalArgumentException` will be thrown.
+| Setting                    | Purpose                   | Default                         |
+|----------------------------|---------------------------|---------------------------------|
+| `prompt.template.source`   | Where templates load from | `ClasspathPromptTemplateSource` |
+| `prompt.template.renderer` | How templates render      | `SimpleTemplateRenderer`        |
 
-`RenderablePromptTemplate` implements both `PromptTemplate` and LangChain4j's `PromptTemplateFactory.Template`
-interfaces. It uses a `TemplateRenderer` to render the template content using provided variables.
+### Add Custom Template Sources
 
-## Customization
-
-You may customize templates via configuration file `langchain4j-kotlin.properties`, located in the classpath.
-
-| Key                        | Description       | Default Value                                                        |
-|----------------------------|-------------------|----------------------------------------------------------------------|
-| `prompt.template.source`   | Template source   | `me.kpavlov.langchain4j.kotlin.prompt.ClasspathPromptTemplateSource` |
-| `prompt.template.renderer` | Template renderer | `me.kpavlov.langchain4j.kotlin.prompt.SimpleTemplateRenderer`        |
-
-### Extending PromptTemplateSource
-
-To create a custom template source, implement the PromptTemplateSource interface:
+Create your own source by implementing `PromptTemplateSource`:
 
 ```kotlin
 interface PromptTemplateSource {
@@ -107,13 +82,9 @@ interface PromptTemplateSource {
 }
 ```
 
-Example implementation for Redis and Jedis:
+Example using Redis:
 
 ```kotlin
-package com.example
-
-// Redis/Jedis-backed template source
-
 class RedisPromptTemplateSource(private val jedis: Jedis) : PromptTemplateSource {
   override fun getTemplate(name: TemplateName): PromptTemplate? {
     return jedis.get(name)?.let {
@@ -123,15 +94,14 @@ class RedisPromptTemplateSource(private val jedis: Jedis) : PromptTemplateSource
 }
 ```
 
-Register your implementation in the `langchain4j-kotlin.properties` configuration file:
-
+Enable it in your properties:
 ```properties
 prompt.template.source=com.example.RedisPromptTemplateSource
 ```
 
-### Extending TemplateRenderer
+### Create Custom Renderers
 
-To create a custom template renderer, implement the TemplateRenderer interface:
+Build your own renderer:
 
 ```kotlin
 interface TemplateRenderer {
@@ -142,27 +112,23 @@ interface TemplateRenderer {
 }
 ```
 
-Example implementation:
-
+Example:
 ```kotlin
-package com.example
-
-// Freemarker-based renderer
 class MyTemplateRenderer : TemplateRenderer {
-
   override fun render(template: TemplateContent, variables: Map<String, Any?>): String {
     TODO("Add implementation here")
   }
 }
 ```
 
-Register your implementation in the `langchain4j-kotlin.properties` configuration file:
-
+Enable it:
 ```properties
 prompt.template.renderer=com.example.MyTemplateRenderer
 ```
 
-## Examples
+## Learn More
 
-You may find the unit test with the
-example [here](../langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt)
+Find complete examples:
+
+- [Unit test example](../langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt)
+- [Using from Java](../samples/src/main/java/me/kpavlov/langchain4j/kotlin/samples/ServiceWithTemplateSourceJavaExample.java)

--- a/docs/PromptTemplates.md
+++ b/docs/PromptTemplates.md
@@ -7,15 +7,13 @@ customization.
 
 Place your prompt templates in the classpath:
 
-System prompt template:
+System prompt template (path: `prompts/default-system-prompt.mustache`):
 ```mustache
-prompts/default-system-prompt.mustache:
 You are helpful assistant using chatMemoryID={{chatMemoryID}}
 ```
 
-User prompt template:
+User prompt template (path: `prompts/default-user-prompt.mustache`):
 ```mustache
-prompts/default-user-prompt.mustache:
 Hello, {{userName}}! {{message}}
 ```
 

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/SystemMessageProvider.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/SystemMessageProvider.kt
@@ -2,16 +2,27 @@ package me.kpavlov.langchain4j.kotlin.service
 
 import me.kpavlov.langchain4j.kotlin.ChatMemoryId
 import me.kpavlov.langchain4j.kotlin.PromptContent
+import java.util.function.Function
 
 /**
  * Interface for providing LLM system messages based on a given chat memory identifier.
  */
-public interface SystemMessageProvider {
+@FunctionalInterface
+interface SystemMessageProvider : Function<ChatMemoryId, PromptContent?> {
     /**
      * Provides a system message based on the given chat memory identifier.
      *
      * @param chatMemoryID Identifier for the chat memory used to generate the system message.
      * @return A system prompt string associated with the provided chat memory identifier, maybe `null`
      */
-    public fun getSystemMessage(chatMemoryID: ChatMemoryId): PromptContent?
+    fun getSystemMessage(chatMemoryID: ChatMemoryId): PromptContent?
+
+    /**
+     * Applies the given chat memory identifier to generate the corresponding system message.
+     *
+     * @param chatMemoryID The identifier representing the chat memory to be used.
+     * @return The prompt content associated with the specified chat memory identifier,
+     * or `null` if no system message is available.
+     */
+    override fun apply(chatMemoryID: ChatMemoryId): PromptContent? = getSystemMessage(chatMemoryID)
 }

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProvider.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TemplateSystemMessageProvider.kt
@@ -14,12 +14,20 @@ import me.kpavlov.langchain4j.kotlin.prompt.TemplateRenderer
  * @property promptTemplateSource Source from which the prompt templates are fetched.
  * @property promptTemplateRenderer Renderer used to render the content with specific variables.
  */
-public open class TemplateSystemMessageProvider(
+open class TemplateSystemMessageProvider(
     private val templateName: TemplateName,
     private val promptTemplateSource: PromptTemplateSource = Configuration.promptTemplateSource,
     private val promptTemplateRenderer: TemplateRenderer = Configuration.promptTemplateRenderer,
 ) : SystemMessageProvider {
-    public open fun templateName(): TemplateName = templateName
+    open fun templateName(): TemplateName = templateName
+
+    constructor(
+        templateName: TemplateName,
+    ) : this(
+        templateName = templateName,
+        promptTemplateSource = Configuration.promptTemplateSource,
+        promptTemplateRenderer = Configuration.promptTemplateRenderer,
+    )
 
     /**
      * Generates a system message using a template and the provided chat memory identifier.

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,10 @@
         <kotlin.code.style>official</kotlin.code.style>
         <java.version>17</java.version>
         <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.compiler.apiVersion>1.9</kotlin.compiler.apiVersion>
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
         <kotlin.compiler.languageVersion>1.9</kotlin.compiler.languageVersion>
-        <kotlin.compiler.apiVersion>1.9</kotlin.compiler.apiVersion>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <!-- Dependencies -->
@@ -275,6 +276,14 @@
                         </args>
                         <javaParameters>true</javaParameters>
                         <multiPlatform>true</multiPlatform>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                    <configuration>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
             </plugins>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>langchain4j-open-ai</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>runtime</scope>
@@ -51,5 +55,65 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/samples/src/main/java/me/kpavlov/langchain4j/kotlin/samples/ServiceWithTemplateSourceJavaExample.java
+++ b/samples/src/main/java/me/kpavlov/langchain4j/kotlin/samples/ServiceWithTemplateSourceJavaExample.java
@@ -1,0 +1,46 @@
+package me.kpavlov.langchain4j.kotlin.samples;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.UserName;
+import dev.langchain4j.service.V;
+import me.kpavlov.langchain4j.kotlin.service.TemplateSystemMessageProvider;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class ServiceWithTemplateSourceJavaExample {
+
+  // Use for demo purposes
+  private static final ChatLanguageModel model = new ChatModelMock("Hello");
+  private static final Logger LOGGER = getLogger(ServiceWithTemplateSourceJavaExample.class);
+
+  private static final String PROMPT_TEMPLATE_PATH = "prompts/ServiceWithTemplateSourceJavaExample";
+
+  private interface Assistant {
+    @UserMessage(PROMPT_TEMPLATE_PATH + "/default-user-prompt.mustache")
+    String askQuestion(
+      @UserName String userName,
+      @V("message") String question
+    );
+  }
+
+  public static void main(String[] args) {
+
+    final var systemMessageProvider = new TemplateSystemMessageProvider(
+      PROMPT_TEMPLATE_PATH + "/default-system-prompt.mustache"
+    );
+
+    final Assistant assistant = AiServices.builder(Assistant.class)
+      .systemMessageProvider(systemMessageProvider)
+      .chatLanguageModel(model)
+      .build();
+
+    String response = assistant.askQuestion("My friend", "How are you?");
+    LOGGER.info("AI Response: {}", response);
+  }
+}
+
+

--- a/samples/src/main/resources/prompts/ServiceWithTemplateSourceJavaExample/default-system-prompt.mustache
+++ b/samples/src/main/resources/prompts/ServiceWithTemplateSourceJavaExample/default-system-prompt.mustache
@@ -1,0 +1,1 @@
+You are helpful assistant using chatMemoryID={{chatMemoryID}}

--- a/samples/src/main/resources/prompts/ServiceWithTemplateSourceJavaExample/default-user-prompt.mustache
+++ b/samples/src/main/resources/prompts/ServiceWithTemplateSourceJavaExample/default-user-prompt.mustache
@@ -1,0 +1,1 @@
+Hello, {{userName}}! {{message}}


### PR DESCRIPTION
Made `SystemMessageProvider` a functional interface and added a default implementation for `apply`. Introduced new Mustache templates for system and user prompts. Updated documentation and examples to simplify prompt template handling. Configured Maven for Kotlin and Java interop while adding proper compiler settings. Added Java sample demonstrating template usage.