### PR TITLE
Refactor error handling for streaming chat flow

### DIFF
--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatLanguageModelIT.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatLanguageModelIT.kt
@@ -74,7 +74,6 @@ internal class StreamingChatLanguageModelIT {
                         }
 
                         is CompleteResponse -> responseRef.set(it.response)
-                        is StreamingChatLanguageModelReply.Error -> fail("Error", it.cause)
                         else -> fail("Unsupported event: $it")
                     }
                 }


### PR DESCRIPTION
Closes #113 

- Removed the `Error` type from `StreamingChatLanguageModelReply` and its usage. Currently the `error` was being emitted twice. Once as an exception, and once as data. We should avoid emitting an event twice, since it only occurs once. It's possible for the user to manually transform the exception into a value using `catch { emit(...) }` as demonstrated in [my other PR](https://github.com/kpavlov/langchain4j-kotlin/pull/116/files#diff-7b90cc7eba5a803d05990cdcd146bd884ffd7a0eb77b2e9d19b13d1e054e3ebfR86). Alternatively we can keep `StreamingChatLanguageModelReply.Error` but not re-emit again on `close(throwable)`. This is a design decision that needs to be made. I don't have a strong preference to be honest, one or the other is fine. You can go back and forth by using `catch` or `throw`.
- Enforces unbounded channel buffer to avoid dropping messages