### PR TITLE
Configure streaming buffer (#113). Replace AssertK assertions with Kotest matchers

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/adapters/TokenStreamToReplyFlowAdapter.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/adapters/TokenStreamToReplyFlowAdapter.kt
@@ -1,10 +1,10 @@
-package me.kpavlov.langchain4j.kotlin.adapters
+package me.kpavlov.langchain4j.kotlin.model.adapters
 
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.spi.services.TokenStreamAdapter
 import kotlinx.coroutines.flow.Flow
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply
-import me.kpavlov.langchain4j.kotlin.model.chat.asReplyFlow
+import me.kpavlov.langchain4j.kotlin.service.asReplyFlow
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/adapters/TokenStreamToStringFlowAdapter.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/adapters/TokenStreamToStringFlowAdapter.kt
@@ -1,9 +1,9 @@
-package me.kpavlov.langchain4j.kotlin.adapters
+package me.kpavlov.langchain4j.kotlin.model.adapters
 
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.spi.services.TokenStreamAdapter
 import kotlinx.coroutines.flow.Flow
-import me.kpavlov.langchain4j.kotlin.model.chat.asFlow
+import me.kpavlov.langchain4j.kotlin.service.asFlow
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
@@ -76,7 +76,15 @@ public sealed interface StreamingChatModelReply {
  * @param bufferCapacity The capacity of the buffer used to store incoming tokens.
  * Default to [Channel.UNLIMITED]
  * @param onBufferOverflow The strategy used to handle buffer overflows when the buffer is full.
- * Default to [BufferOverflow.SUSPEND]
+ * Default to [BufferOverflow.SUSPEND]. The available strategies are:
+ * - [BufferOverflow.SUSPEND]: Suspends the producer until there is space in the buffer. This is
+ *   suitable for scenarios where maintaining the order of all emitted items is critical.
+ * - [BufferOverflow.DROP_OLDEST]: Drops the oldest item in the buffer to make space for the new
+ *   item. This is useful when the latest data is more relevant than older data, such as in real-time
+ *   updates or streaming dashboards.
+ * - [BufferOverflow.DROP_LATEST]: Drops the new item if the buffer is full. This is appropriate
+ *   when older data must be preserved, and losing the latest data is acceptable, such as in logging
+ *   or audit trails.
  * @param block A lambda with receiver on [ChatRequestBuilder] used to configure
  * the [dev.langchain4j.model.chat.request.ChatRequest] by adding messages and/or setting parameters.
  *

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
@@ -142,30 +142,3 @@ public fun StreamingChatModel.chatFlow(
             logger.info("Flow is canceled")
         }
     }.buffer(bufferCapacity, onBufferOverflow)
-
-public fun TokenStream.asFlow(): Flow<String> =
-    flow {
-        callbackFlow {
-            onPartialResponse { trySend(it) }
-            onCompleteResponse { close() }
-            onError { close(it) }
-            start()
-            awaitClose()
-        }.buffer(Channel.UNLIMITED).collect(this)
-    }
-
-public fun TokenStream.asReplyFlow(): Flow<StreamingChatModelReply> =
-    flow {
-        callbackFlow<StreamingChatModelReply> {
-            onPartialResponse { token ->
-                trySend(StreamingChatModelReply.PartialResponse(token))
-            }
-            onCompleteResponse { response ->
-                trySend(StreamingChatModelReply.CompleteResponse(response))
-                close()
-            }
-            onError { throwable -> close(throwable) }
-            start()
-            awaitClose()
-        }.buffer(Channel.UNLIMITED).collect(this)
-    }

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
@@ -4,6 +4,7 @@ import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.chat.response.ChatResponse
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler
 import dev.langchain4j.service.TokenStream
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -72,6 +73,10 @@ public sealed interface StreamingChatModelReply {
  * and manages the streaming process by handling partial responses, complete
  * responses, and errors through a LC4J's [dev.langchain4j.model.chat.response.StreamingChatResponseHandler].
  *
+ * @param bufferCapacity The capacity of the buffer used to store incoming tokens.
+ * Default to [Channel.UNLIMITED]
+ * @param onBufferOverflow The strategy used to handle buffer overflows when the buffer is full.
+ * Default to [BufferOverflow.SUSPEND]
  * @param block A lambda with receiver on [ChatRequestBuilder] used to configure
  * the [dev.langchain4j.model.chat.request.ChatRequest] by adding messages and/or setting parameters.
  *
@@ -79,7 +84,10 @@ public sealed interface StreamingChatModelReply {
  * types of replies during the chat interaction, including partial responses,
  * final responses, and errors.
  */
+@JvmOverloads
 public fun StreamingChatModel.chatFlow(
+    bufferCapacity: Int = Channel.UNLIMITED,
+    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND,
     block: ChatRequestBuilder.() -> Unit,
 ): Flow<StreamingChatModelReply> =
     callbackFlow {
@@ -125,7 +133,7 @@ public fun StreamingChatModel.chatFlow(
             // cleanup
             logger.info("Flow is canceled")
         }
-    }
+    }.buffer(bufferCapacity, onBufferOverflow)
 
 public fun TokenStream.asFlow(): Flow<String> =
     flow {

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TokenStreamExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/TokenStreamExtensions.kt
@@ -1,0 +1,44 @@
+package me.kpavlov.langchain4j.kotlin.service
+
+import dev.langchain4j.model.chat.StreamingChatModel
+import dev.langchain4j.model.chat.response.ChatResponse
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler
+import dev.langchain4j.service.TokenStream
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
+import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply
+import me.kpavlov.langchain4j.kotlin.model.chat.request.ChatRequestBuilder
+import me.kpavlov.langchain4j.kotlin.model.chat.request.chatRequest
+import org.slf4j.LoggerFactory
+
+public fun TokenStream.asFlow(): Flow<String> =
+    flow {
+        callbackFlow {
+            onPartialResponse { trySend(it) }
+            onCompleteResponse { close() }
+            onError { close(it) }
+            start()
+            awaitClose()
+        }.buffer(Channel.UNLIMITED).collect(this)
+    }
+
+public fun TokenStream.asReplyFlow(): Flow<StreamingChatModelReply> =
+    flow {
+        callbackFlow<StreamingChatModelReply> {
+            onPartialResponse { token ->
+                trySend(StreamingChatModelReply.PartialResponse(token))
+            }
+            onCompleteResponse { response ->
+                trySend(StreamingChatModelReply.CompleteResponse(response))
+                close()
+            }
+            onError { throwable -> close(throwable) }
+            start()
+            awaitClose()
+        }.buffer(Channel.UNLIMITED).collect(this)
+    }

--- a/langchain4j-kotlin/src/main/resources/META-INF/services/dev.langchain4j.spi.services.TokenStreamAdapter
+++ b/langchain4j-kotlin/src/main/resources/META-INF/services/dev.langchain4j.spi.services.TokenStreamAdapter
@@ -1,2 +1,2 @@
-me.kpavlov.langchain4j.kotlin.adapters.TokenStreamToStringFlowAdapter
-me.kpavlov.langchain4j.kotlin.adapters.TokenStreamToReplyFlowAdapter
+me.kpavlov.langchain4j.kotlin.model.adapters.TokenStreamToStringFlowAdapter
+me.kpavlov.langchain4j.kotlin.model.adapters.TokenStreamToReplyFlowAdapter

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/adapters/ServiceWithFlowTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/adapters/ServiceWithFlowTest.kt
@@ -14,6 +14,9 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler
 import dev.langchain4j.service.AiServices
 import dev.langchain4j.service.UserName
 import dev.langchain4j.service.V
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.toList
@@ -21,6 +24,7 @@ import kotlinx.coroutines.test.runTest
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply.CompleteResponse
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply.PartialResponse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -28,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
+import kotlin.collections.listOf
 
 @ExtendWith(MockitoExtension::class)
 internal class ServiceWithFlowTest {
@@ -59,7 +64,7 @@ internal class ServiceWithFlowTest {
                     .askQuestion(userName = "My friend", question = "How are you?")
                     .toList()
 
-            assertThat(result).containsExactly(partialToken1, partialToken2)
+            result shouldContainExactly listOf(partialToken1, partialToken2)
         }
 
     @Test
@@ -93,7 +98,7 @@ internal class ServiceWithFlowTest {
                         emit(message)
                     }.toList()
 
-            assertThat(response).containsExactly(partialToken1, partialToken2, error.message)
+            response shouldContainExactly listOf(partialToken1, partialToken2, error.message)
         }
 
     @Test
@@ -124,7 +129,7 @@ internal class ServiceWithFlowTest {
             assertThat(
                 result,
             ).startsWith(PartialResponse(partialToken1), PartialResponse(partialToken2))
-            assertThat(result).index(2).isInstanceOf(CompleteResponse::class)
+            assertTrue(result[2] is CompleteResponse)
         }
 
     @Test
@@ -157,7 +162,7 @@ internal class ServiceWithFlowTest {
             assertThat(
                 response,
             ).startsWith(PartialResponse(partialToken1), PartialResponse(partialToken2))
-            assertThat(response).index(2).isInstanceOf(StreamingChatModelReply.Error::class)
+            assertTrue(response[2] is StreamingChatModelReply.Error)
         }
 
     @Suppress("unused")

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/data/document/AsyncDocumentLoaderTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/data/document/AsyncDocumentLoaderTest.kt
@@ -1,14 +1,15 @@
 package me.kpavlov.langchain4j.kotlin.data.document
 
-import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.containsExactlyInAnyOrder
-import assertk.assertions.hasSize
-import assertk.assertions.isNotEmpty
-import assertk.assertions.isNotNull
 import dev.langchain4j.data.document.DocumentSource
 import dev.langchain4j.data.document.parser.TextDocumentParser
 import dev.langchain4j.data.document.source.FileSystemSource
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotBeEmpty
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -38,16 +39,16 @@ internal class AsyncDocumentLoaderTest {
     fun `Should load documents asynchronously`() =
         runTest {
             val document = loadAsync(documentSource, parser)
-            assertThat(document.text()).contains("Captain Blood")
-            assertThat(document.metadata()).isNotNull()
+            document.text() shouldContain "Captain Blood"
+            document.metadata() shouldNotBe null
         }
 
     @Test
     fun `Should parse documents asynchronously`() =
         runTest {
             val document = parser.parseAsync(documentSource.inputStream())
-            assertThat(document.text()).contains("Captain Blood")
-            assertThat(document.metadata()).isNotNull()
+            document.text() shouldContain "Captain Blood"
+            document.metadata() shouldNotBe null
         }
 
     @Test
@@ -82,8 +83,8 @@ internal class AsyncDocumentLoaderTest {
                     .filterNotNull()
 
             documents.forEach {
-                assertThat(it.text()).isNotEmpty()
-                assertThat(it.metadata()).isNotNull()
+                it.text().shouldNotBeEmpty()
+                it.metadata() shouldNotBe null
             }
         }
 
@@ -96,15 +97,13 @@ internal class AsyncDocumentLoaderTest {
                     documentParser = parser,
                     directoryPaths = listOf(Path.of("./src/test/resources/data")),
                 )
-            assertThat(documents)
-                .hasSize(3)
+            documents shouldHaveSize 3
 
             val documentNames = documents.map { it.metadata().getString("file_name") }
-            assertThat(documentNames)
-                .containsExactlyInAnyOrder(
-                    "captain-blood.txt",
-                    "quantum-computing.txt",
-                    "blumblefang.txt",
-                )
+            documentNames shouldContainExactlyInAnyOrder listOf(
+                "captain-blood.txt",
+                "quantum-computing.txt",
+                "blumblefang.txt",
+            )
         }
 }

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/ChatModelExtensionsKtTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/ChatModelExtensionsKtTest.kt
@@ -1,10 +1,9 @@
 package me.kpavlov.langchain4j.kotlin.model.chat
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.request.ChatRequest
 import dev.langchain4j.model.chat.response.ChatResponse
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -40,7 +39,7 @@ internal class ChatModelExtensionsKtTest {
 
             val actualResponse = mockModel.chatAsync(request)
 
-            assertThat(actualResponse).isEqualTo(expectedResponse)
+            actualResponse shouldBe expectedResponse
             verify(mockModel).chat(request)
         }
 
@@ -52,7 +51,7 @@ internal class ChatModelExtensionsKtTest {
 
             val actualResponse = mockModel.chatAsync(requestBuilder)
 
-            assertThat(actualResponse).isEqualTo(expectedResponse)
+            actualResponse shouldBe expectedResponse
             verify(mockModel).chat(request)
         }
 
@@ -64,7 +63,7 @@ internal class ChatModelExtensionsKtTest {
 
             val actualResponse = mockModel.chat(requestBuilder)
 
-            assertThat(actualResponse).isEqualTo(expectedResponse)
+            actualResponse shouldBe expectedResponse
             verify(mockModel).chat(request)
         }
 }

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensionsKtTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensionsKtTest.kt
@@ -1,15 +1,14 @@
 package me.kpavlov.langchain4j.kotlin.model.chat
 
-import assertk.assertFailure
-import assertk.assertThat
-import assertk.assertions.containsExactly
-import assertk.assertions.hasMessage
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.UserMessage.userMessage
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.chat.request.ChatRequest
 import dev.langchain4j.model.chat.response.ChatResponse
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.throwable.shouldHaveMessage
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply.CompleteResponse
@@ -50,9 +49,7 @@ internal class StreamingChatModelExtensionsKtTest {
             val result = flow.toList()
 
             // Assert partial responses
-            assertThat(
-                result,
-            ).containsExactly(
+            result shouldContainExactly listOf(
                 PartialResponse(partialToken1),
                 PartialResponse(partialToken2),
                 CompleteResponse(completeResponse),
@@ -78,8 +75,10 @@ internal class StreamingChatModelExtensionsKtTest {
                     messages += userMessage("Hey, there!")
                 }
 
-            assertFailure {
+            val exception = shouldThrow<RuntimeException> {
                 flow.toList()
-            }.hasMessage("Test error")
+            }
+            
+            exception shouldHaveMessage "Test error"
         }
 }

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/request/ChatRequestExtensionsTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/request/ChatRequestExtensionsTest.kt
@@ -1,11 +1,5 @@
 package me.kpavlov.langchain4j.kotlin.model.chat.request
 
-import assertk.assertThat
-import assertk.assertions.containsExactly
-import assertk.assertions.isCloseTo
-import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotEqualTo
 import dev.langchain4j.agent.tool.ToolSpecification
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.data.message.UserMessage
@@ -14,6 +8,12 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters
 import dev.langchain4j.model.chat.request.ResponseFormat
 import dev.langchain4j.model.chat.request.ToolChoice
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.doubles.shouldBeWithinPercentageOf
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beInstanceOf
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 
@@ -33,12 +33,12 @@ internal class ChatRequestExtensionsTest {
                 parameters = params
             }
 
-        assertThat(result.messages()).containsExactly(
+        result.messages() shouldContainExactly listOf(
             systemMessage,
             userMessage,
         )
-        assertThat(result.parameters()).isEqualTo(params)
-        assertThat(result.parameters().temperature()).isNotEqualTo(0.1)
+        result.parameters() shouldBe params
+        result.parameters().temperature() shouldNotBe 0.1
     }
 
     @Test
@@ -66,18 +66,18 @@ internal class ChatRequestExtensionsTest {
                 }
             }
         val parameters = result.parameters()
-        assertThat(parameters).isInstanceOf(DefaultChatRequestParameters::class)
-        assertThat(parameters.temperature()).isCloseTo(0.1, 0.000001)
-        assertThat(parameters.modelName()).isEqualTo("super-model")
-        assertThat(parameters.topP()).isCloseTo(0.2, 0.000001)
-        assertThat(parameters.topK()).isEqualTo(3)
-        assertThat(parameters.frequencyPenalty()).isCloseTo(0.4, 0.000001)
-        assertThat(parameters.presencePenalty()).isCloseTo(0.5, 0.000001)
-        assertThat(parameters.maxOutputTokens()).isEqualTo(6)
-        assertThat(parameters.stopSequences()).containsExactly("halt", "stop")
-        assertThat(parameters.toolSpecifications()).containsExactly(toolSpec)
-        assertThat(parameters.toolChoice()).isEqualTo(ToolChoice.REQUIRED)
-        assertThat(parameters.responseFormat()).isEqualTo(ResponseFormat.JSON)
+        parameters should beInstanceOf<DefaultChatRequestParameters>()
+        parameters.temperature().shouldBeWithinPercentageOf(0.1, 0.000001)
+        parameters.modelName() shouldBe "super-model"
+        parameters.topP().shouldBeWithinPercentageOf(0.2, 0.000001)
+        parameters.topK() shouldBe 3
+        parameters.frequencyPenalty().shouldBeWithinPercentageOf(0.4, 0.000001)
+        parameters.presencePenalty().shouldBeWithinPercentageOf(0.5, 0.000001)
+        parameters.maxOutputTokens() shouldBe 6
+        parameters.stopSequences() shouldContainExactly listOf("halt", "stop")
+        parameters.toolSpecifications() shouldContainExactly listOf(toolSpec)
+        parameters.toolChoice() shouldBe ToolChoice.REQUIRED
+        parameters.responseFormat() shouldBe ResponseFormat.JSON
     }
 
     @Test
@@ -94,7 +94,7 @@ internal class ChatRequestExtensionsTest {
                 }
             }
         val parameters = result.parameters() as OpenAiChatRequestParameters
-        assertThat(parameters.temperature()).isCloseTo(0.1, 0.000001)
-        assertThat(parameters.seed()).isEqualTo(42)
+        parameters.temperature().shouldBeWithinPercentageOf(0.1, 0.000001)
+        parameters.seed() shouldBe 42
     }
 }


### PR DESCRIPTION
- fix: Update Flow extension to prevent potentially dropping messages #113 - Thanks to @nomisRev for rising the issue!
- chore: Updates the test suite by replacing AssertK assertions with Kotest matchers, streamlining test expressions and improving consistency across the codebase.
- refactor: TokenStream extension methods and update package structure