### PR TITLE
#113 Replace StreamingChatLanguageModelReply.Error with throwing exception

### DIFF
--- a/langchain4j-kotlin/pom.xml
+++ b/langchain4j-kotlin/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.kotest</groupId>
-            <artifactId>kotest-assertions-core-jvm</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelExtensions.kt
@@ -47,19 +47,6 @@ public sealed interface StreamingChatModelReply {
     public data class CompleteResponse(
         val response: ChatResponse,
     ) : StreamingChatModelReply
-
-    /**
-     * Represents an error that occurred during the streaming process
-     * when generating a reply from the AI language model. This type
-     * of reply is used to indicate a failure in the operation and
-     * provides details about the cause of the error.
-     *
-     * @property cause The underlying exception or error that caused the failure.
-     * @see StreamingChatResponseHandler.onError
-     */
-    public data class Error(
-        val cause: Throwable,
-    ) : StreamingChatModelReply
 }
 
 /**
@@ -126,7 +113,6 @@ public fun StreamingChatModel.chatFlow(
                         error.message,
                         error,
                     )
-                    trySend(StreamingChatModelReply.Error(error))
                     close(error)
                 }
             }

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/ReflectionVariableResolver.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/ReflectionVariableResolver.kt
@@ -70,7 +70,6 @@ internal object ReflectionVariableResolver {
             Optional.empty()
         }
 
-
     fun findUserName(
         parameters: Array<Parameter>,
         args: Array<Any?>,
@@ -111,7 +110,10 @@ internal object ReflectionVariableResolver {
         return Optional.empty()
     }
 
-    private fun findMemoryIdParameter(method: Method, args: Array<Any?>): Pair<Parameter, Any?>? {
+    private fun findMemoryIdParameter(
+        method: Method,
+        args: Array<Any?>,
+    ): Pair<Parameter, Any?>? {
         for (i in args.indices) {
             val parameter = method.parameters[i]
             if (parameter.isAnnotationPresent(MemoryId::class.java)) {

--- a/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/memory/ChatMemoryServiceExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/me/kpavlov/langchain4j/kotlin/service/memory/ChatMemoryServiceExtensions.kt
@@ -16,12 +16,9 @@ public suspend fun ChatMemoryService.getOrCreateChatMemoryAsync(
 public suspend fun ChatMemoryService.getChatMemoryAsync(
     memoryId: ChatMemoryId,
     context: CoroutineContext = Dispatchers.IO,
-): ChatMemory? =
-    withContext(context)
-    { this@getChatMemoryAsync.getChatMemory(memoryId) }
+): ChatMemory? = withContext(context) { this@getChatMemoryAsync.getChatMemory(memoryId) }
 
 public suspend fun ChatMemoryService.evictChatMemoryAsync(
     memoryId: ChatMemoryId,
     context: CoroutineContext = Dispatchers.IO,
-): ChatMemory? =
-    withContext(context) { this@evictChatMemoryAsync.evictChatMemory(memoryId) }
+): ChatMemory? = withContext(context) { this@evictChatMemoryAsync.evictChatMemory(memoryId) }

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelIT.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/model/chat/StreamingChatModelIT.kt
@@ -16,7 +16,6 @@ import me.kpavlov.langchain4j.kotlin.loadDocument
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply.CompleteResponse
 import me.kpavlov.langchain4j.kotlin.model.chat.StreamingChatModelReply.PartialResponse
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -64,8 +63,7 @@ internal open class StreamingChatModelIT {
                 .chatFlow {
                     messages += systemMessage
                     messages += userMessage
-                }
-                .collect {
+                }.collect {
                     when (it) {
                         is PartialResponse -> {
                             println("Token: '${it.token}'")
@@ -73,7 +71,6 @@ internal open class StreamingChatModelIT {
                         }
 
                         is CompleteResponse -> responseRef.set(it.response)
-                        is StreamingChatModelReply.Error -> fail("Error", it.cause)
                     }
                 }
 

--- a/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/me/kpavlov/langchain4j/kotlin/service/ServiceWithPromptTemplatesTest.kt
@@ -18,45 +18,46 @@ import org.junit.jupiter.api.Test
 
 internal class ServiceWithPromptTemplatesTest {
     @Test
-    fun `Should use System and User Prompt Templates`() = runTest {
-        val chatResponse =
-            ChatResponse
-                .builder()
-                .aiMessage(AiMessage("I'm fine, thanks"))
-                .build()
+    fun `Should use System and User Prompt Templates`() =
+        runTest {
+            val chatResponse =
+                ChatResponse
+                    .builder()
+                    .aiMessage(AiMessage("I'm fine, thanks"))
+                    .build()
 
-        val model =
-            object : ChatModel {
-                override fun chat(chatRequest: ChatRequest): ChatResponse {
-                    chatRequest.messages() shouldHaveSize 2
-                    val systemMessage =
-                        chatRequest.messages().first { it is SystemMessage } as SystemMessage
-                    val userMessage =
-                        chatRequest.messages().first {
-                            it is UserMessage
-                        } as UserMessage
+            val model =
+                object : ChatModel {
+                    override fun chat(chatRequest: ChatRequest): ChatResponse {
+                        chatRequest.messages() shouldHaveSize 2
+                        val systemMessage =
+                            chatRequest.messages().first { it is SystemMessage } as SystemMessage
+                        val userMessage =
+                            chatRequest.messages().first {
+                                it is UserMessage
+                            } as UserMessage
 
-                    systemMessage.text() shouldBe
-                        "You are helpful assistant using chatMemoryID=default"
-                    userMessage.singleText() shouldBe "Hello, My friend! How are you?"
+                        systemMessage.text() shouldBe
+                            "You are helpful assistant using chatMemoryID=default"
+                        userMessage.singleText() shouldBe "Hello, My friend! How are you?"
 
-                    return chatResponse
+                        return chatResponse
+                    }
                 }
-            }
 
-        val assistant =
-            AiServices
-                .builder(Assistant::class.java)
-                .systemMessageProvider(
-                    TemplateSystemMessageProvider(
-                        "prompts/ServiceWithTemplatesTest/default-system-prompt.mustache",
-                    ),
-                ).chatModel(model)
-                .build()
+            val assistant =
+                AiServices
+                    .builder(Assistant::class.java)
+                    .systemMessageProvider(
+                        TemplateSystemMessageProvider(
+                            "prompts/ServiceWithTemplatesTest/default-system-prompt.mustache",
+                        ),
+                    ).chatModel(model)
+                    .build()
 
-        val response = assistant.askQuestion(userName = "My friend", question = "How are you?")
-        assertThat(response).isEqualTo("I'm fine, thanks")
-    }
+            val response = assistant.askQuestion(userName = "My friend", question = "How are you?")
+            assertThat(response).isEqualTo("I'm fine, thanks")
+        }
 
     @Suppress("unused")
     private interface Assistant {

--- a/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/AsyncAiServiceExample.kt
+++ b/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/AsyncAiServiceExample.kt
@@ -6,24 +6,26 @@ import kotlinx.coroutines.runBlocking
 import me.kpavlov.langchain4j.kotlin.service.AsyncAiServicesFactory
 import me.kpavlov.langchain4j.kotlin.service.createAiService
 
-
 fun interface AsyncAssistant {
-    suspend fun askQuestion(@UserMessage question: String): String
+    suspend fun askQuestion(
+        @UserMessage question: String,
+    ): String
 }
 
 class AsyncAiServiceExample(
-    private val model: ChatModel
+    private val model: ChatModel,
 ) {
     suspend fun callAiService(): String {
-        val assistant = createAiService(
-            serviceClass = AsyncAssistant::class.java,
-            factory = AsyncAiServicesFactory(),
-        ).chatModel(model)
-            .systemMessageProvider { "You are a helpful software engineer" }
-            .build()
+        val assistant =
+            createAiService(
+                serviceClass = AsyncAssistant::class.java,
+                factory = AsyncAiServicesFactory(),
+            ).chatModel(model)
+                .systemMessageProvider { "You are a helpful software engineer" }
+                .build()
 
         return assistant.askQuestion(
-            "What's new in Kotlin/AI space in one sentence?"
+            "What's new in Kotlin/AI space in one sentence?",
         )
     }
 }

--- a/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/Environment.kt
+++ b/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/Environment.kt
@@ -6,7 +6,9 @@ import me.kpavlov.finchly.BaseTestEnvironment
 
 val testEnv = BaseTestEnvironment()
 
-val model: ChatModel = OpenAiChatModel.builder()
-    .modelName("gpt-4o-nano")
-    .apiKey(testEnv["OPENAI_API_KEY"])
-    .build()
+val model: ChatModel =
+    OpenAiChatModel
+        .builder()
+        .modelName("gpt-4o-nano")
+        .apiKey(testEnv["OPENAI_API_KEY"])
+        .build()

--- a/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/OpenAiChatModelExample.kt
+++ b/samples/src/main/kotlin/me/kpavlov/langchain4j/kotlin/samples/OpenAiChatModelExample.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.runBlocking
 import me.kpavlov.langchain4j.kotlin.model.chat.chatAsync
 
 class OpenAiChatModelExample(
-    private val model: ChatModel
+    private val model: ChatModel,
 ) {
     suspend fun callChatAsync(): String {
         val response =


### PR DESCRIPTION
Removed the Error type from StreamingChatLanguageModelReply and its usage. Currently the error was being emitted twice. Once as an exception, and once as data. We should avoid emitting an event twice, since it only occurs once. It's possible for the user to manually transform the exception into a value using catch { emit(...) }

Closes #113

Integrated changes from https://github.com/kpavlov/langchain4j-kotlin/pull/117 by @nomisRev :

> Removed the Error type from StreamingChatLanguageModelReply and its usage. Currently the error was being emitted twice. Once as an exception, and once as data. We should avoid emitting an event twice, since it only occurs once. It's possible for the user to manually transform the exception into a value using catch { emit(...) } as demonstrated in [my other PR](https://github.com/kpavlov/langchain4j-kotlin/pull/116/files#diff-7b90cc7eba5a803d05990cdcd146bd884ffd7a0eb77b2e9d19b13d1e054e3ebfR86).

